### PR TITLE
chore: default root to current git repo root

### DIFF
--- a/proj.py
+++ b/proj.py
@@ -5,7 +5,8 @@ def real(p): return os.path.realpath(p)
 
 def main():
     # Root + markers (customize via env)
-    root = real(os.environ.get("MONOREPO_ROOT", os.getcwd()))
+    git_root = subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8", "ignore").strip()
+    root = real(os.environ.get("MONOREPO_ROOT", git_root))
     markers = os.environ.get(
         "PROJECT_MARKERS",
         "package.json go.mod pyproject.toml Cargo.toml BUILD.bazel pom.xml setup.cfg",


### PR DESCRIPTION
Default `MONOREPO_ROOT` to the root of the current git repo. This allows for you to use this tool across multiple git repos without needing to configure environment variables.